### PR TITLE
[EFR32] Add app description to .application_properties section

### DIFF
--- a/examples/platforms/efr32/Makefile.am
+++ b/examples/platforms/efr32/Makefile.am
@@ -62,6 +62,9 @@ libopenthread_efr32_a_CPPFLAGS                                                = 
     -I$(EFR32MG_SDK_SRCDIR)/platform/emdrv/dmadrv/inc                           \
     -I$(EFR32MG_SDK_SRCDIR)/platform/emdrv/rtcdrv/inc                           \
     -I$(EFR32MG_SDK_SRCDIR)/platform/emlib/inc                                  \
+    -I$(EFR32MG_SDK_SRCDIR)/platform/base/hal/micro/cortexm3                    \
+    -I$(EFR32MG_SDK_SRCDIR)/platform/bootloader/api                             \
+    -I$(EFR32MG_SDK_SRCDIR)/protocol/bluetooth_2.4/ble_stack/inc/soc            \
     -Wno-unused-parameter                                                       \
     $(NULL)
 

--- a/examples/platforms/efr32/platform-efr32.h
+++ b/examples/platforms/efr32/platform-efr32.h
@@ -37,6 +37,7 @@
 
 #include <openthread/config.h>
 #include <openthread-core-config.h>
+#include "application_properties.h"
 #include "em_device.h"
 #include "em_system.h"
 #include "core_cm4.h"
@@ -95,5 +96,7 @@ void efr32MiscInit(void);
  *
  */
 void efr32RandomInit(void);
+
+extern const ApplicationProperties_t applicationProperties;
 
 #endif  // PLATFORM_EFR32_H_

--- a/examples/platforms/efr32/platform.c
+++ b/examples/platforms/efr32/platform.c
@@ -32,22 +32,22 @@
  *   This file includes the platform-specific initializers.
  */
 
+#include <openthread/platform/uart.h>
 #include <string.h>
 
-#include <openthread/platform/uart.h>
-
-#include "common/logging.hpp"
-
-#include "pa.h"
-#include "pti.h"
+#include "application_properties.h"
+#include "bg_version.h"
 #include "bsp.h"
-#include "em_emu.h"
-#include "em_cmu.h"
+#include "common/logging.hpp"
 #include "em_chip.h"
+#include "em_cmu.h"
+#include "em_emu.h"
+#include "openthread-core-efr32-config.h"
+#include "pa.h"
 #include "platform-efr32.h"
+#include "pti.h"
 #include "rail.h"
 #include "rail_ieee802154.h"
-#include "openthread-core-efr32-config.h"
 
 otInstance *sInstance;
 
@@ -148,3 +148,18 @@ void HAL_Init(void)
 {
     halInitChipSpecific();
 }
+
+__attribute__((used))
+__attribute__ ((section(".application_properties")))
+const ApplicationProperties_t applicationProperties = {
+    .magic = APPLICATION_PROPERTIES_MAGIC,
+    .structVersion = APPLICATION_PROPERTIES_VERSION,
+    .signatureType = APPLICATION_SIGNATURE_NONE,
+    .signatureLocation = 0,
+    .app = {
+        .type = APPLICATION_TYPE_THREAD,
+        .version = 0,
+        .capabilities = (BG_VERSION_MAJOR << 24) | (BG_VERSION_MINOR << 16) | (BG_VERSION_PATCH << 8),
+        .productId = {0},
+    },
+};


### PR DESCRIPTION
The .application_properties section allows for external tools to sign
the compiled binary.

```
[deva-xubuntu~/Code/openthread/output/efr32/bin] $ \ls | xargs -t -I% sh -c   "readelf -S % | grep app"
sh -c readelf -S ot-cli-ftd | grep app
  [ 1] .application_prop PROGBITS        00000000 010000 000058 00   A  0   0  4
sh -c readelf -S ot-cli-mtd | grep app
  [ 1] .application_prop PROGBITS        00000000 010000 000058 00   A  0   0  4
sh -c readelf -S ot-ncp-ftd | grep app
  [ 1] .application_prop PROGBITS        00000000 010000 000058 00   A  0   0  4
sh -c readelf -S ot-ncp-mtd | grep app
  [ 1] .application_prop PROGBITS        00000000 010000 000058 00   A  0   0  4
```